### PR TITLE
Fixed the locale issue where I18n.locale overrides he_IL to he-IL

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 # Settings specified here will take precedence over those in config/environment.rb
 
-config.log_level = :info
+config.log_level = :debug
 
 # In the development environment your application's code is reloaded on
 # every request.  This slows down response time but is perfect for development

--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -1,6 +1,16 @@
+require "i18n/backend/fallbacks" 
 FastGettext.add_text_domain 'app', :path => File.join(Rails.root, 'locale'), :type => :po
 FastGettext.default_text_domain = 'app'
 
 I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 
 RoutingFilter::Locale.include_default_locale = Configuration::include_default_locale_in_urls
+
+#This monkey patch fixes the locale issue where the gem gettext_i18n_rails dasherizes every locale.
+module I18n
+  class Config
+    def locale
+      FastGettext.locale
+    end
+  end
+end


### PR DESCRIPTION
- The gem gettext_i18n_rails had a behavior where each time a locale
  was set on I18n.locale, it would dasherize the locale. I've added
  a monkey patch to the gettext initializer that solves this issue.
- Changed log level to debug for development
